### PR TITLE
Remove TiltedCore version pin

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -3,7 +3,7 @@ set_languages("cxx17")
 set_xmakever("2.5.1")
 
 -- direct dependency version pinning
-add_requires("tiltedcore v0.2.7", "hopscotch-map v2.3.1", "catch2 2.13.9", "mem 1.0.0")
+add_requires("tiltedcore", "hopscotch-map v2.3.1", "catch2 2.13.9", "mem 1.0.0")
 
 -- dependencies' dependencies version pinning
 add_requireconfs("*.mimalloc", { version = "2.1.7"}) -- no override because TiltedReverse dependency


### PR DESCRIPTION
Submodules inherit pins from their parent, so it is counter-productive to have pins in them.